### PR TITLE
Add explicit DSL declaration

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,6 @@
 #!/usr/bin/env nextflow 
+nextflow.enable.dsl=2
+
 params.timeout = 10 
 params.exit = 0
 params.cmd = "echo 'Hello (timeout $params.timeout)'"


### PR DESCRIPTION
Adding the explicit declaration for DSL2, to avoid the launch failure on `tower.nf` 

![image](https://user-images.githubusercontent.com/12799326/175011920-539b8b63-0ee4-474e-bfd4-b2939878ec77.png)
